### PR TITLE
Added support for `use` keyword in anonymous functions, e.g.:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [1.2.0] - ????-??-?
+## [1.2.0] - 2018-09-29
 
-* Added support for `use` keyword in anonymous functions, e.g.:
+Added support for `use` keyword in anonymous functions, e.g.:
 
 ```php
 <?php
@@ -29,7 +29,7 @@ object(Closure) #1 (5) {
 }
 ```
 
-## [1.1.0] - 2019-09-14
+## [1.1.0] - 2018-09-14
 
 * Added [`Awesomite\VarDumper\SymfonyVarDumper`](./src/SymfonyVarDumper.php)
 * Refactor - all `@internal` classes have been marked as `final` whenever it was possible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.2.0] - ????-??-?
+
+* Added support for `use` keyword in anonymous functions, e.g.:
+
+```php
+<?php
+
+use Awesomite\VarDumper\LightVarDumper;
+
+$x = 5;
+$y = 6;
+
+$fn = function () use ($x, $y) {
+};
+
+$dumper = new LightVarDumper();
+$dumper->dump($fn);
+```
+
+```
+object(Closure) #1 (5) {
+    $name =>      “{closure}”
+    $filename =>  “(...)/file.php”
+    $startLine => 8
+    $endLine =>   9
+    $use =>       array(2) {[x] => 5, [y] => 6}
+}
+```
+
 ## [1.1.0] - 2019-09-14
 
 * Added [`Awesomite\VarDumper\SymfonyVarDumper`](./src/SymfonyVarDumper.php)
@@ -23,7 +52,9 @@ whenever object contains method [`__get`](http://php.net/manual/en/language.oop5
 * In some cases method `LightVarDumper::dump` didn't work properly, because the following code triggers
 error `Notice: Undefined property: Foo::$a` in PHP ^7.0, fixed issue:
 
-```
+```php
+<?php
+
 class Foo
 {
     private $a = 'a';
@@ -45,6 +76,7 @@ $reflectionProp->getValue($obj);
 
 This version contains the same source code as [0.12.0].
 
+[1.2.0]: https://github.com/awesomite/var-dumper/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/awesomite/var-dumper/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/awesomite/var-dumper/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/awesomite/var-dumper/compare/v1.0.1...v1.0.2

--- a/src/Properties/PropertiesClosure.php
+++ b/src/Properties/PropertiesClosure.php
@@ -54,6 +54,10 @@ final class PropertiesClosure implements PropertiesInterface
             }
         }
 
+        if ($vars = $reflection->getStaticVariables()) {
+            $result[] = $this->createProperty('use', $vars);
+        }
+
         return $result;
     }
 

--- a/tests/Properties/PropertiesTest.php
+++ b/tests/Properties/PropertiesTest.php
@@ -141,6 +141,7 @@ final class PropertiesTest extends BaseTestCase
     {
         $result = array(
             $this->getClosureData(),
+            $this->getClosureDataWithUse(),
         );
 
         // https://travis-ci.org/awesomite/var-dumper/jobs/240526896
@@ -168,6 +169,35 @@ final class PropertiesTest extends BaseTestCase
         if (\version_compare(PHP_VERSION, '5.4') >= 0) {
             $properties[] = $fnCreateProperty('closureScopeClass', \get_class($this));
         }
+
+        return array(
+            $closure,
+            $properties,
+        );
+    }
+
+    private function getClosureDataWithUse()
+    {
+        $a = 1;
+        $b = null;
+        $c = new \stdClass();
+
+        $fnCreateProperty = function ($name, $value) {
+            return new VarProperty($name, $value, VarProperty::VISIBILITY_PUBLIC, 'Closure', false, true);
+        };
+
+        $closure = function () use ($a, $b, $c) {
+        };
+        $properties = array(
+            $fnCreateProperty('name', __NAMESPACE__ . '\\{closure}'),
+            $fnCreateProperty('filename', __FILE__),
+            $fnCreateProperty('startLine', __LINE__ - 5),
+            $fnCreateProperty('endLine', __LINE__ - 5),
+        );
+        if (\version_compare(PHP_VERSION, '5.4') >= 0) {
+            $properties[] = $fnCreateProperty('closureScopeClass', \get_class($this));
+        }
+        $properties[] = $fnCreateProperty('use', array('a' => $a, 'b' => $b, 'c' => $c));
 
         return array(
             $closure,


### PR DESCRIPTION
```php
<?php

use Awesomite\VarDumper\LightVarDumper;

$x = 5;
$y = 6;

$fn = function () use ($x, $y) {
};

$dumper = new LightVarDumper();
$dumper->dump($fn);
```

```
object(Closure) #1 (5) {
    $name =>      “{closure}”
    $filename =>  “(...)/file.php”
    $startLine => 8
    $endLine =>   9
    $use =>       array(2) {[x] => 5, [y] => 6}
}
```